### PR TITLE
Potential fix for code scanning alert no. 5: Double escaping or unescaping

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -90,9 +90,9 @@ function sanitizeMessage(message) {
     // More appropriate HTML sanitization for chat messages
     // Only escape the most dangerous characters while preserving readability
     return message
+        .replace(/&/g, '&amp;')
         .replace(/</g, '&lt;')
         .replace(/>/g, '&gt;')
-        .replace(/&/g, '&amp;')
         .trim();
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/NotYarazi/room21/security/code-scanning/5](https://github.com/NotYarazi/room21/security/code-scanning/5)

To fix the issue, the `sanitizeMessage` function should escape the `&` character first before escaping `<` and `>`. This ensures that any existing escaped entities like `&lt;` or `&gt;` are not double-escaped. The order of replacements in the function should be adjusted accordingly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
