### PR TITLE
Potential fix for code scanning alert no. 3: Regular expression injection

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "node-fetch": "^3.3.2",
     "path": "^0.12.7",
     "ws": "^8.18.0",
-    "express-rate-limit": "^8.0.1"
+    "express-rate-limit": "^8.0.1",
+    "lodash": "^4.17.21"
   }
 }

--- a/src/public/js/script.js
+++ b/src/public/js/script.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 document.addEventListener('DOMContentLoaded', () => {
     const chatBox = document.getElementById('chat-box');
     const inputField = document.getElementById('input-field');
@@ -145,7 +146,8 @@ document.addEventListener('DOMContentLoaded', () => {
         });
         
         // Check for mentions
-        const mentionPattern = new RegExp(`@${currentUsername}\\b`, 'i');
+        const safeUsername = _.escapeRegExp(currentUsername);
+        const mentionPattern = new RegExp(`@${safeUsername}\\b`, 'i');
         const isMentioned = mentionPattern.test(message);
         
         if (isMentioned) {


### PR DESCRIPTION
Potential fix for [https://github.com/NotYarazi/room21/security/code-scanning/3](https://github.com/NotYarazi/room21/security/code-scanning/3)

To fix the issue, we need to sanitize `currentUsername` before embedding it into the regular expression. This can be achieved using a function like `_.escapeRegExp` from the lodash library, which escapes special characters in a string to ensure it is safe for use in a regular expression. The fix involves importing lodash, sanitizing `currentUsername` before constructing the regular expression, and ensuring the rest of the functionality remains unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
